### PR TITLE
Pluggable backends

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.2.5)
+    minitest (5.8.4)
     rake (10.3.2)
     redis (3.2.0)
     rr (1.1.2)
@@ -30,7 +31,11 @@ PLATFORMS
 
 DEPENDENCIES
   cb2!
+  minitest
   rake (> 0)
   rr (~> 1.1)
   rspec (~> 3.1)
   timecop (~> 0.7)
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     cb2 (0.0.3)
-      redis (~> 3.1)
 
 GEM
   remote: http://rubygems.org/
@@ -10,7 +9,7 @@ GEM
     diff-lcs (1.2.5)
     minitest (5.8.4)
     rake (10.3.2)
-    redis (3.2.0)
+    redis (2.2.2)
     rr (1.1.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -33,6 +32,7 @@ DEPENDENCIES
   cb2!
   minitest
   rake (> 0)
+  redis (~> 2.1)
   rr (~> 1.1)
   rspec (~> 3.1)
   timecop (~> 0.7)

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "redis", "~> 3.1"
+  s.add_development_dependency "redis",   "~> 2.1"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rr",      "~> 1.1"
   s.add_development_dependency "rspec",   "~> 3.1"

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rr",      "~> 1.1"
   s.add_development_dependency "rspec",   "~> 3.1"
   s.add_development_dependency "timecop", "~> 0.7"
+  s.add_development_dependency "minitest"
 end

--- a/lib/cb2.rb
+++ b/lib/cb2.rb
@@ -1,10 +1,17 @@
-require "redis"
-
 module CB2
+  def self.backend=(backend)
+    @backend = backend
+  end
+
+  def self.backend
+    @backend
+  end
 end
 
 require "cb2/breaker"
 require "cb2/error"
+require "cb2/backends"
+require "cb2/strategies/base"
 require "cb2/strategies/rolling_window"
 require "cb2/strategies/percentage"
 require "cb2/strategies/stub"

--- a/lib/cb2/backends.rb
+++ b/lib/cb2/backends.rb
@@ -1,0 +1,3 @@
+module CB2::Backends
+  BackendError = Class.new(StandardError)
+end

--- a/lib/cb2/backends/redis.rb
+++ b/lib/cb2/backends/redis.rb
@@ -1,0 +1,48 @@
+require "redis"
+
+module CB2::Backends
+  class Redis
+    attr_reader :redis
+
+    def initialize(options = {})
+      @redis = options[:redis] || Redis.current
+    end
+
+    def delete(key)
+      catch_redis { redis.del(key) }
+    end
+
+    def set(key, val)
+      catch_redis { redis.set(key, val) }
+    end
+
+    def get(key)
+      catch_redis { redis.get(key) }
+    end
+
+    def count(key)
+      catch_redis { redis.zcard(key) }
+    end
+
+    def remove_range(key, min, max)
+      min = "-inf" if min.nil?
+      catch_redis { redis.zremrangebyscore(key, min, max) }
+    end
+
+    def add_to_weighted_set(key, weight, val)
+      catch_redis { redis.zadd(key, weight, val) }
+    end
+
+    def atomic(&block)
+      return_set = catch_redis { redis.pipelined(&block) }
+      return_set.last # blocks like this tend to return the last
+    end
+
+    private
+      def catch_redis
+        yield
+      rescue Redis::BaseError => e
+        raise BackendError, "Redis Connection issues: #{e}"
+      end
+  end
+end

--- a/lib/cb2/strategies/base.rb
+++ b/lib/cb2/strategies/base.rb
@@ -1,0 +1,9 @@
+module CB2::Strategies
+  class Base
+    def process(type)
+      send(type) if respond_to?(type)
+    rescue Backends::BackendError
+      nil
+    end
+  end
+end

--- a/lib/cb2/strategies/percentage.rb
+++ b/lib/cb2/strategies/percentage.rb
@@ -1,3 +1,5 @@
+require "cb2/strategies/base"
+
 class CB2::Percentage < CB2::RollingWindow
   # keep a rolling window of all calls too
   def count

--- a/lib/cb2/strategies/rolling_window.rb
+++ b/lib/cb2/strategies/rolling_window.rb
@@ -8,7 +8,7 @@ class CB2::RollingWindow < CB2::Strategies::Base
     @duration       = options.fetch(:duration)
     @threshold      = options.fetch(:threshold)
     @reenable_after = options.fetch(:reenable_after)
-    @backend          = options[:backend] || CB2.backend
+    @backend        = options[:backend] || CB2.backend
   end
 
   def open?

--- a/lib/cb2/strategies/stub.rb
+++ b/lib/cb2/strategies/stub.rb
@@ -1,11 +1,15 @@
-class CB2::Stub
-  attr_accessor :allow
+require "cb2/strategies/base"
 
-  def initialize(options)
-    @allow = options.fetch(:allow)
-  end
+module CB2
+  class Stub < Strategies::Base
+    attr_accessor :allow
 
-  def open?
-    !allow
+    def initialize(options)
+      @allow = options.fetch(:allow)
+    end
+
+    def open?
+      !allow
+    end
   end
 end

--- a/spec/backends/redis_spec.rb
+++ b/spec/backends/redis_spec.rb
@@ -1,0 +1,78 @@
+require "spec_helper"
+
+describe CB2::RollingWindow do
+  let(:backend) do
+    CB2::Backends::Redis.new(:redis => redis)
+  end
+
+  let(:redis) { Redis.new }
+
+  describe "#delete" do
+    it "deletes a key" do
+      redis.set("foo", true)
+      assert redis.get("foo")
+      backend.delete("foo")
+      assert redis.get("foo").nil?
+    end
+  end
+
+  describe "#set" do
+    it "sets a key" do
+      backend.set("foo", "bar")
+      assert_equal "bar", redis.get("foo")
+    end
+  end
+
+  describe "#get" do
+    it "gets a key" do
+      redis.set("foo", "bar")
+      assert_equal "bar", backend.get("foo")
+    end
+  end
+
+  describe "#count" do
+    it "counts a key" do
+      redis.zadd("foo", 1, "bar")
+      redis.zadd("foo", 2, "baz")
+      assert_equal 2, backend.count("foo")
+    end
+  end
+
+  describe "#remove_range" do
+    it "removes all and down" do
+      redis.zadd("foo", 1, "bar")
+      redis.zadd("foo", 2, "baz")
+      redis.zadd("foo", 3, "biz")
+      backend.remove_range("foo", nil, 2)
+      assert_equal 1, backend.count("foo")
+    end
+
+    it "removes a mid-range" do
+      redis.zadd("foo", 1, "bar")
+      redis.zadd("foo", 2, "baz")
+      redis.zadd("foo", 3, "biz")
+      redis.zadd("foo", 4, "fiz")
+      backend.remove_range("foo", 2, 3)
+      assert_equal 2, backend.count("foo")
+    end
+  end
+
+  describe "#add_to_weighted_set" do
+    it "adds to a set" do
+      backend.add_to_weighted_set("foo", 1, "bar")
+      assert_equal 1, backend.count("foo")
+    end
+  end
+
+  describe "#atomic" do
+    it "does a set of operations and returns the last" do
+      ret = backend.atomic do
+        backend.add_to_weighted_set("foo", 1, "bar")
+        backend.remove_range("foo", nil, 1)
+        backend.add_to_weighted_set("foo", 1, "bar")
+        backend.count("foo")
+      end
+      assert_equal 1, ret
+    end
+  end
+end

--- a/spec/breaker_spec.rb
+++ b/spec/breaker_spec.rb
@@ -26,7 +26,7 @@ describe CB2::Breaker do
     end
 
     it "handles Redis errors, just consider the circuit closed" do
-      stub(breaker.strategy).open? { raise Redis::BaseError }
+      stub(breaker.strategy).open? { raise CB2::Backends::BackendError }
       refute breaker.open?
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,11 @@ Bundler.setup
 require "timecop"
 require "cb2"
 
+require 'redis'
+
 # establish a Redis connection to the default server (localhost:6379)
-Redis.new
+require 'cb2/backends/redis'
+CB2.backend = CB2::Backends::Redis.new(:redis => Redis.new)
 
 RSpec.configure do |config|
   config.expect_with :minitest


### PR DESCRIPTION
- Initialize backed strategies with a `:backend` option
- Permits flexibility and plugability if someone wants to support a
  an older version of redis, memory or another store entirely
- The basic API for a backend would be to match the
  `lib/cb2/backends/redis.rb` public method API
- To keep the same basic functionality you can now initialize a breaker
  like so:

``` ruby
breaker = CB2::Breaker.new(
  service: "aws"
  duration: 60,
  threshold: 5,
  reenable_after: 600,
  backend: CB2::Backends::Redis.new(:redis => Redis.new))
```

Also moves redis dependency to a development dependency for testing and moves the version back to test older version.

The option change (`redis` => `backend`) makes this is a breaking change as well as the redis move. If you _are_ interested in this change and would more comfortable, we could talk about options to roll into this change across a couple separate releases to ease the change.
