### PR TITLE
Allow passing classes for creating custom breaker strategies.

### DIFF
--- a/lib/cb2/breaker.rb
+++ b/lib/cb2/breaker.rb
@@ -47,7 +47,7 @@ class CB2::Breaker
   def initialize_strategy(options)
     strategy_options = options.dup.merge(service: self.service)
 
-    if options[:strategy].respond_to?(:open?)
+    if options[:strategy].is_a?(Class) && options[:strategy].method_defined?(:open?)
       return options[:strategy].new(strategy_options)
     end
 

--- a/spec/strategies/custom_spec.rb
+++ b/spec/strategies/custom_spec.rb
@@ -12,19 +12,15 @@ class CustomStrategy
 end
 
 describe CB2::Breaker do
-  let(:breaker) do
-
-  end
-
   describe "#initialize" do
-    it "initializes the strategy" do
+    it "initializes a custom strategy" do
       breaker = CB2::Breaker.new(
           strategy:  CustomStrategy,
           duration:  60,
           threshold: 10,
           reenable_after: 600)
-      assert breaker.strategy.is_a?(CustomStrategy)
       assert breaker.strategy.initialized
+      assert breaker.strategy.is_a?(CustomStrategy)
     end
   end
 end

--- a/spec/strategies/custom_spec.rb
+++ b/spec/strategies/custom_spec.rb
@@ -1,10 +1,17 @@
 require "spec_helper"
 
-class CustomStrategy < CB2::Percentage
+class CustomStrategy
+  attr_accessor :initialized
 
+  def initialize(options)
+    @initialized = true
+  end
+
+  def open?
+  end
 end
 
-describe CB2::Percentage do
+describe CB2::Breaker do
   let(:breaker) do
 
   end
@@ -16,7 +23,8 @@ describe CB2::Percentage do
           duration:  60,
           threshold: 10,
           reenable_after: 600)
-      assert breaker.strategy
+      assert breaker.strategy.is_a?(CustomStrategy)
+      assert breaker.strategy.initialized
     end
   end
 end

--- a/spec/strategies/custom_spec.rb
+++ b/spec/strategies/custom_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+class CustomStrategy < CB2::Percentage
+
+end
+
+describe CB2::Percentage do
+  let(:breaker) do
+
+  end
+
+  describe "#initialize" do
+    it "initializes the strategy" do
+      breaker = CB2::Breaker.new(
+          strategy:  CustomStrategy,
+          duration:  60,
+          threshold: 10,
+          reenable_after: 600)
+      assert breaker.strategy
+    end
+  end
+end


### PR DESCRIPTION
I believe this is the intent of the current initialize_strategy code, but respond_to? is an instance, not class method, so currently a custom strategy would need to be passed in as an instance.

With this patch a custom strategy can be passed in as a class:

```
CB2::Breaker.new(
      strategy:  CustomStrategy,
      duration:  60,
      threshold: 10,
      reenable_after: 600)
```
