### PR TITLE
Redis 4 Support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     diff-lcs (1.2.5)
+    minitest (5.13.0)
     rake (10.3.2)
     redis (3.2.0)
     rr (1.1.2)
@@ -30,7 +31,11 @@ PLATFORMS
 
 DEPENDENCIES
   cb2!
+  minitest (~> 5.13.0)
   rake (> 0)
   rr (~> 1.1)
   rspec (~> 3.1)
   timecop (~> 0.7)
+
+BUNDLED WITH
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cb2 (0.0.3)
-      redis (~> 3.1)
+      redis (~> 4.0)
 
 GEM
   remote: http://rubygems.org/
@@ -10,7 +10,7 @@ GEM
     diff-lcs (1.2.5)
     minitest (5.13.0)
     rake (10.3.2)
-    redis (3.2.0)
+    redis (4.1.3)
     rr (1.1.2)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     cb2 (0.0.3)
-      redis (~> 4.0)
+      redis (~> 4.0, >= 3.1)
 
 GEM
   remote: http://rubygems.org/

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -15,4 +15,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rr",      "~> 1.1"
   s.add_development_dependency "rspec",   "~> 3.1"
   s.add_development_dependency "timecop", "~> 0.7"
+  s.add_development_dependency "minitest", "~> 5.13.0"
 end

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "redis", "~> 4.0"
+  s.add_dependency "redis", ">= 3.1", "~> 4.0"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rr",      "~> 1.1"
   s.add_development_dependency "rspec",   "~> 3.1"

--- a/cb2.gemspec
+++ b/cb2.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.files = Dir["lib/**/*.rb"] + Dir["Gemfile*"]
   s.require_paths = ["lib"]
 
-  s.add_dependency "redis", "~> 3.1"
+  s.add_dependency "redis", "~> 4.0"
   s.add_development_dependency "rake",    "> 0"
   s.add_development_dependency "rr",      "~> 1.1"
   s.add_development_dependency "rspec",   "~> 3.1"

--- a/lib/cb2/breaker.rb
+++ b/lib/cb2/breaker.rb
@@ -20,7 +20,7 @@ class CB2::Breaker
       raise e
     end
 
-    return ret
+    ret
   end
 
   def open?

--- a/lib/cb2/strategies/percentage.rb
+++ b/lib/cb2/strategies/percentage.rb
@@ -11,6 +11,6 @@ class CB2::Percentage < CB2::RollingWindow
     return false if @current_count < 5
 
     error_perc = error_count * 100 / @current_count.to_f
-    return error_perc >= threshold
+    error_perc >= threshold
   end
 end

--- a/lib/cb2/strategies/rolling_window.rb
+++ b/lib/cb2/strategies/rolling_window.rb
@@ -1,3 +1,5 @@
+require 'securerandom'
+
 class CB2::RollingWindow
   attr_accessor :service, :duration, :threshold, :reenable_after, :redis
 

--- a/lib/cb2/strategies/rolling_window.rb
+++ b/lib/cb2/strategies/rolling_window.rb
@@ -44,7 +44,7 @@ class CB2::RollingWindow
 
   def trip!
     @last_open = Time.now.to_i
-    redis.set(key, @last_open)
+    redis.set(key, @last_open.to_s)
   end
 
   # generate a key to use in redis
@@ -59,13 +59,13 @@ class CB2::RollingWindow
     t   = Time.now.to_i
     pipeline = redis.pipelined do
       # keep the sorted set clean
-      redis.zremrangebyscore(key, "-inf", t - duration)
+      redis.zremrangebyscore(key, "-inf", (t - duration).to_s)
       # add as a random uuid because sorted sets won't take duplicate items:
       redis.zadd(key, t, SecureRandom.uuid)
       # just count how many errors are left in the set
       redis.zcard(key)
     end
-    return pipeline.last # return the count
+    pipeline.last # return the count
   end
 
   def should_open?(error_count)

--- a/spec/strategies/rolling_window_spec.rb
+++ b/spec/strategies/rolling_window_spec.rb
@@ -51,7 +51,7 @@ describe CB2::RollingWindow do
     it "resets the counter so half open breakers go back to closed" do
       redis.set(strategy.key, Time.now.to_i - 601)
       strategy.success
-      assert_equal nil, redis.get(strategy.key)
+      assert_nil redis.get(strategy.key)
     end
   end
 


### PR DESCRIPTION
- Updated dependencies to support both Redis 3.x and 4.x.
- Made specs run out of the box.
- Removed some unnecessary `return` statements.
- Made sure expected types were sent to Redis.

References #10 